### PR TITLE
Event properties should be public

### DIFF
--- a/src/Events/MissingEnvVars.php
+++ b/src/Events/MissingEnvVars.php
@@ -8,7 +8,7 @@ class MissingEnvVars
 {
     use Dispatchable;
 
-    protected $diffs;
+    public $diffs;
 
     public function __construct($diffs)
     {


### PR DESCRIPTION
Event properties should be public to get them in a listener (also see docs: https://laravel.com/docs/8.x/events#defining-events)